### PR TITLE
Fixes #597

### DIFF
--- a/konig-dao-sql-runtime/src/main/java/io/konig/sql/runtime/BigQueryChartSeriesFactory.java
+++ b/konig-dao-sql-runtime/src/main/java/io/konig/sql/runtime/BigQueryChartSeriesFactory.java
@@ -1,6 +1,5 @@
 package io.konig.sql.runtime;
 
-import com.google.appengine.api.memcache.MemcacheService;
 import com.google.appengine.api.memcache.MemcacheServiceFactory;
 
 /*
@@ -54,7 +53,7 @@ public class BigQueryChartSeriesFactory extends SqlGenerator implements ChartSer
 				.getMemcacheService()
 				.get("FusionIdMapping");
 		if(mapping == null){			
-			ChartGeoLocationMapping mapping = new BigQueryFusionChartService(bigQuery)
+			ChartGeoLocationMapping mapping = new BigQueryFusionChartService(bigQuery , seriesRequest.getStruct().getMediaTypeBaseName())
 					.getFusionIdMapping();
 			MemcacheServiceFactory.getMemcacheService().put("FusionIdMapping", mapping);
 			

--- a/konig-dao-sql-runtime/src/main/java/io/konig/sql/runtime/BigQueryFusionChartService.java
+++ b/konig-dao-sql-runtime/src/main/java/io/konig/sql/runtime/BigQueryFusionChartService.java
@@ -36,13 +36,18 @@ import io.konig.dao.core.DaoException;
 
 public class BigQueryFusionChartService {
 	private BigQuery bigQuery;
-	
-	public BigQueryFusionChartService(BigQuery bigQuery){
-		this.bigQuery = bigQuery;	
+	private String mediaTypeBaseName;
+	public BigQueryFusionChartService(BigQuery bigQuery , String mediaTypeBaseName){
+		this.bigQuery = bigQuery;
+		this.mediaTypeBaseName = mediaTypeBaseName;
 	}
 	
 	public ChartGeoLocationMapping getFusionIdMapping() throws DaoException {
-		String sql = "SELECT * FROM pearsonmypedia.FusionMapping";
+		
+		ClasspathEntityStructureService structureService = ClasspathEntityStructureService.defaultInstance();
+		EntityStructure struct = structureService.forMediaType(mediaTypeBaseName);
+		String datasetId = struct.getName().split("\\.")[0];
+		String sql = "SELECT * FROM "+datasetId+".FusionMapping";
 		QueryRequest request = QueryRequest.newBuilder(sql).setUseLegacySql(false).build();
 		QueryResponse response = bigQuery.query(request);
 		while (!response.jobCompleted()) {

--- a/konig-dao-sql-runtime/src/main/java/io/konig/sql/runtime/ClasspathEntityStructureService.java
+++ b/konig-dao-sql-runtime/src/main/java/io/konig/sql/runtime/ClasspathEntityStructureService.java
@@ -232,6 +232,9 @@ public class ClasspathEntityStructureService implements EntityStructureService {
 
 	@Override
 	public EntityStructure forMediaType(String mediaTypeBaseName) throws DaoException {
+		if(mediaTypeMap == null) {
+			init();
+		}
 		String shapeId = mediaTypeMap.get(mediaTypeBaseName);
 		if (shapeId == null) {
 			throw new DaoException("EntityStructure not found for media type: " + mediaTypeBaseName);

--- a/konig-data-app-gcp/src/main/java/io/konig/data/app/gae/GaeDataAppServlet.java
+++ b/konig-data-app-gcp/src/main/java/io/konig/data/app/gae/GaeDataAppServlet.java
@@ -23,25 +23,16 @@ package io.konig.data.app.gae;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
-import java.util.HashMap;
 
 import javax.servlet.ServletException;
-import javax.cache.Cache;
-import javax.cache.CacheFactory;
-import javax.cache.CacheManager;
 
-import com.google.appengine.api.memcache.MemcacheService;
-import com.google.appengine.api.memcache.MemcacheServiceFactory;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 
-import io.konig.dao.core.ChartGeoLocationMapping;
 import io.konig.dao.core.ShapeReadService;
 import io.konig.data.app.common.AppEngineUtil;
 import io.konig.data.app.common.DataAppServlet;
-import io.konig.sql.runtime.BigQueryFusionChartService;
 import io.konig.sql.runtime.BigQueryShapeReadService;
 import io.konig.sql.runtime.ClasspathEntityStructureService;
 
@@ -54,23 +45,9 @@ public class GaeDataAppServlet extends DataAppServlet {
 			GoogleCredentials credentials = GoogleCredentials.fromStream(input);
 			BigQuery bigQuery = BigQueryOptions.newBuilder().setCredentials(credentials).build().getService();
 			ClasspathEntityStructureService structureService = ClasspathEntityStructureService.defaultInstance();
-			configureFusionIdMappingCache(bigQuery);
 			return new BigQueryShapeReadService(structureService, bigQuery);
 		} catch (IOException e) {
 			throw new ServletException(e);
 		}
 	}
-
-	private void configureFusionIdMappingCache(BigQuery bigQuery) throws ServletException {
-		MemcacheService syncCache = MemcacheServiceFactory.getMemcacheService();
-		try {
-			ChartGeoLocationMapping mapping = new BigQueryFusionChartService(bigQuery)
-					.getFusionIdMapping();
-			syncCache.put("FusionIdMapping", mapping);
-		} catch (Exception e) {
-			throw new ServletException(e);
-		}
-
-	}
-
 }


### PR DESCRIPTION
Removed the caching for Fusion Mapping on the servlet init 
Removed the hard coded dataset from the BigQueryFusionChartService 
BigQueryFusionChartService dynamically choose an appropriate dataset based on the API route