### PR TITLE
closes #585

### DIFF
--- a/konig-data-catalog/src/test/java/io/konig/datacatalog/DataCatalogBuilderTest.java
+++ b/konig-data-catalog/src/test/java/io/konig/datacatalog/DataCatalogBuilderTest.java
@@ -56,7 +56,13 @@ public class DataCatalogBuilderTest {
 		}
 		outDir.mkdirs();
 	}
-	
+
+	@Test
+	public void testShape() throws Exception {
+		URI ontologyId = uri("http://schema.pearson.com/ns/fact/");
+		test("src/test/resources/ShapePageTest/rdf", ontologyId);
+	}
+
 	@Test
 	public void testHierarchicalNames() throws Exception {
 		URI ontologyId = uri("http://example.com/ns/categories/");

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/alias.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/alias.ttl
@@ -1,0 +1,58 @@
+@prefix alias: <http://schema.pearson.com/ns/alias/> .
+@prefix fact: <http://schema.pearson.com/ns/fact/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix reg: <https://schema.pearson.com/ns/registrar/> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xas: <http://schema.pearson.com/ns/activity/> .
+
+alias: a owl:Ontology ; 
+	vann:preferredNamespacePrefix "alias" ; 
+	rdfs:label "Alias Namespace" ; 
+	rdfs:comment "A namespace for properties that derived from other properties." . 
+
+alias:assessmentId a owl:ObjectProperty . 
+
+alias:assessmentMode a owl:ObjectProperty ; 
+	schema:domainIncludes fact:StartAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCount , fact:CompleteAssessmentUniqueCountBySection , fact:CompleteAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySchool , fact:CompleteAssessmentUniqueCountByCity , fact:CompleteAssessmentUniqueCountByState , fact:CompleteAssessmentUniqueCountByCountry , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountByGrade , fact:ScoreAssessmentUniqueCountBySchool , fact:ScoreAssessmentUniqueCountByCity , fact:ScoreAssessmentUniqueCountByState , fact:ScoreAssessmentUniqueCountByCountry , fact:ScoreAssessmentAverageScore , fact:ScoreAssessmentAverageScoreBySection , fact:ScoreAssessmentAverageScoreByGrade , fact:ScoreAssessmentAverageScoreBySchool , fact:ScoreAssessmentAverageScoreByCity , fact:ScoreAssessmentAverageScoreByState , fact:ScoreAssessmentAverageScoreByCountry , fact:AssessmentEndeavorNotComplete , fact:AssessmentEndeavorNotCompleteBySection , fact:AssessmentEndeavorNotCompleteByGrade , fact:AssessmentEndeavorNotCompleteBySchool , fact:AssessmentEndeavorNotCompleteByCity , fact:AssessmentEndeavorNotCompleteByState , fact:AssessmentEndeavorNotCompleteByCountry ; 
+	schema:rangeIncludes xas:assessmentMode , xas:AssessmentMode . 
+
+alias:assessmentName a owl:ObjectProperty . 
+
+alias:assessmentType a owl:ObjectProperty . 
+
+alias:city a owl:ObjectProperty ; 
+	schema:domainIncludes fact:LoginUniqueCountByGrade , fact:StartAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySection , fact:CompleteAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySchool , fact:CompleteAssessmentUniqueCountByCity , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountByGrade , fact:ScoreAssessmentUniqueCountBySchool , fact:ScoreAssessmentUniqueCountByCity , fact:ScoreAssessmentAverageScoreBySection , fact:ScoreAssessmentAverageScoreByGrade , fact:ScoreAssessmentAverageScoreBySchool , fact:ScoreAssessmentAverageScoreByCity , fact:AssessmentEndeavorNotCompleteBySection , fact:AssessmentEndeavorNotCompleteByGrade , fact:AssessmentEndeavorNotCompleteBySchool , fact:AssessmentEndeavorNotCompleteByCity ; 
+	schema:rangeIncludes schema:City . 
+
+alias:country a owl:ObjectProperty ; 
+	schema:domainIncludes fact:LoginUniqueCountByGrade , fact:StartAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySection , fact:CompleteAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySchool , fact:CompleteAssessmentUniqueCountByCity , fact:CompleteAssessmentUniqueCountByState , fact:CompleteAssessmentUniqueCountByCountry , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountByGrade , fact:ScoreAssessmentUniqueCountBySchool , fact:ScoreAssessmentUniqueCountByCity , fact:ScoreAssessmentUniqueCountByState , fact:ScoreAssessmentUniqueCountByCountry , fact:ScoreAssessmentAverageScoreBySection , fact:ScoreAssessmentAverageScoreByGrade , fact:ScoreAssessmentAverageScoreBySchool , fact:ScoreAssessmentAverageScoreByCity , fact:ScoreAssessmentAverageScoreByState , fact:ScoreAssessmentAverageScoreByCountry , fact:AssessmentEndeavorNotCompleteBySection , fact:AssessmentEndeavorNotCompleteByGrade , fact:AssessmentEndeavorNotCompleteBySchool , fact:AssessmentEndeavorNotCompleteByCity , fact:AssessmentEndeavorNotCompleteByState , fact:AssessmentEndeavorNotCompleteByCountry ; 
+	schema:rangeIncludes schema:Country . 
+
+alias:grade a owl:ObjectProperty ; 
+	schema:domainIncludes fact:LoginUniqueCountByGrade , fact:StartAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySection , fact:CompleteAssessmentUniqueCountByGrade , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountByGrade , fact:ScoreAssessmentAverageScoreBySection , fact:ScoreAssessmentAverageScoreByGrade , fact:AssessmentEndeavorNotCompleteBySection , fact:AssessmentEndeavorNotCompleteByGrade ; 
+	schema:rangeIncludes reg:SchoolGrade . 
+
+alias:school a owl:ObjectProperty ; 
+	schema:domainIncludes fact:LoginUniqueCountByGrade , fact:StartAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySection , fact:CompleteAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySchool , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountByGrade , fact:ScoreAssessmentUniqueCountBySchool , fact:ScoreAssessmentAverageScoreBySection , fact:ScoreAssessmentAverageScoreByGrade , fact:ScoreAssessmentAverageScoreBySchool , fact:AssessmentEndeavorNotCompleteBySection , fact:AssessmentEndeavorNotCompleteByGrade , fact:AssessmentEndeavorNotCompleteBySchool ; 
+	schema:rangeIncludes schema:School . 
+
+alias:schoolURI a owl:ObjectProperty . 
+
+alias:section a owl:ObjectProperty ; 
+	schema:domainIncludes fact:CompleteAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentAverageScoreBySection , fact:AssessmentEndeavorNotCompleteBySection ; 
+	schema:rangeIncludes reg:GradeSection . 
+
+alias:startDateTime a owl:ObjectProperty . 
+
+alias:state a owl:ObjectProperty ; 
+	schema:domainIncludes fact:StartAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySection , fact:CompleteAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySchool , fact:CompleteAssessmentUniqueCountByCity , fact:CompleteAssessmentUniqueCountByState , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountByGrade , fact:ScoreAssessmentUniqueCountBySchool , fact:ScoreAssessmentUniqueCountByCity , fact:ScoreAssessmentUniqueCountByState , fact:ScoreAssessmentAverageScoreBySection , fact:ScoreAssessmentAverageScoreByGrade , fact:ScoreAssessmentAverageScoreBySchool , fact:ScoreAssessmentAverageScoreByCity , fact:ScoreAssessmentAverageScoreByState , fact:AssessmentEndeavorNotCompleteBySection , fact:AssessmentEndeavorNotCompleteByGrade , fact:AssessmentEndeavorNotCompleteBySchool , fact:AssessmentEndeavorNotCompleteByCity , fact:AssessmentEndeavorNotCompleteByState ; 
+	schema:rangeIncludes schema:State . 
+
+alias:studentAnonymousId a owl:ObjectProperty . 
+
+alias:subject a owl:ObjectProperty ; 
+	schema:domainIncludes fact:StartAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCount , fact:CompleteAssessmentUniqueCountBySection , fact:CompleteAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySchool , fact:CompleteAssessmentUniqueCountByCity , fact:CompleteAssessmentUniqueCountByState , fact:CompleteAssessmentUniqueCountByCountry , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountByGrade , fact:ScoreAssessmentUniqueCountBySchool , fact:ScoreAssessmentUniqueCountByCity , fact:ScoreAssessmentUniqueCountByState , fact:ScoreAssessmentUniqueCountByCountry , fact:ScoreAssessmentAverageScore , fact:ScoreAssessmentAverageScoreBySection , fact:ScoreAssessmentAverageScoreByGrade , fact:ScoreAssessmentAverageScoreBySchool , fact:ScoreAssessmentAverageScoreByCity , fact:ScoreAssessmentAverageScoreByState , fact:ScoreAssessmentAverageScoreByCountry , fact:AssessmentEndeavorNotComplete , fact:AssessmentEndeavorNotCompleteBySection , fact:AssessmentEndeavorNotCompleteByGrade , fact:AssessmentEndeavorNotCompleteBySchool , fact:AssessmentEndeavorNotCompleteByCity , fact:AssessmentEndeavorNotCompleteByState , fact:AssessmentEndeavorNotCompleteByCountry ; 
+	schema:rangeIncludes skos:Concept . 

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/fact.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/fact.ttl
@@ -1,0 +1,83 @@
+@prefix fact: <http://schema.pearson.com/ns/fact/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+
+fact: a owl:Ontology ; 
+	vann:preferredNamespacePrefix "fact" ; 
+	rdfs:label "Pearson Fact Ontology" ; 
+	rdfs:comment "Pearson's ontology for Facts" . 
+
+fact:AssessmentEndeavorNotComplete a owl:Class . 
+
+fact:AssessmentEndeavorNotCompleteByCity a owl:Class . 
+
+fact:AssessmentEndeavorNotCompleteByCountry a owl:Class . 
+
+fact:AssessmentEndeavorNotCompleteByGrade a owl:Class . 
+
+fact:AssessmentEndeavorNotCompleteBySchool a owl:Class . 
+
+fact:AssessmentEndeavorNotCompleteBySection a owl:Class . 
+
+fact:AssessmentEndeavorNotCompleteByState a owl:Class . 
+
+fact:CompleteAssessmentUniqueCount a owl:Class . 
+
+fact:CompleteAssessmentUniqueCountByCity a owl:Class . 
+
+fact:CompleteAssessmentUniqueCountByCountry a owl:Class . 
+
+fact:CompleteAssessmentUniqueCountByGrade a owl:Class . 
+
+fact:CompleteAssessmentUniqueCountBySchool a owl:Class . 
+
+fact:CompleteAssessmentUniqueCountBySection a owl:Class . 
+
+fact:CompleteAssessmentUniqueCountByState a owl:Class . 
+
+fact:LoginUniqueCountByCity a owl:Class . 
+
+fact:LoginUniqueCountByCountry a owl:Class . 
+
+fact:LoginUniqueCountByGrade a owl:Class . 
+
+fact:LoginUniqueCountBySchool a owl:Class . 
+
+fact:ScoreAssessmentAverageScore a owl:Class . 
+
+fact:ScoreAssessmentAverageScoreByCity a owl:Class . 
+
+fact:ScoreAssessmentAverageScoreByCountry a owl:Class . 
+
+fact:ScoreAssessmentAverageScoreByGrade a owl:Class . 
+
+fact:ScoreAssessmentAverageScoreBySchool a owl:Class . 
+
+fact:ScoreAssessmentAverageScoreBySection a owl:Class . 
+
+fact:ScoreAssessmentAverageScoreByState a owl:Class . 
+
+fact:ScoreAssessmentUniqueCount a owl:Class . 
+
+fact:ScoreAssessmentUniqueCountByCity a owl:Class . 
+
+fact:ScoreAssessmentUniqueCountByCountry a owl:Class . 
+
+fact:ScoreAssessmentUniqueCountByGrade a owl:Class . 
+
+fact:ScoreAssessmentUniqueCountBySchool a owl:Class . 
+
+fact:ScoreAssessmentUniqueCountBySection a owl:Class . 
+
+fact:ScoreAssessmentUniqueCountByState a owl:Class . 
+
+fact:StartAssessmentUniqueCountByCity a owl:Class . 
+
+fact:StartAssessmentUniqueCountByCountry a owl:Class . 
+
+fact:StartAssessmentUniqueCountByGrade a owl:Class . 
+
+fact:StartAssessmentUniqueCountBySchool a owl:Class . 
+
+fact:StartAssessmentUniqueCountByState a owl:Class . 

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/konig.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/konig.ttl
@@ -1,0 +1,42 @@
+@prefix fact: <http://schema.pearson.com/ns/fact/> .
+@prefix konig: <http://www.konig.io/ns/core/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+konig: a owl:Ontology ; 
+	vann:preferredNamespacePrefix "konig" ; 
+	rdfs:label "Konig Core Ontology" ; 
+	rdfs:comment "A vocabulary for enriched semantic models that enable ontology-based engineering solutions." . 
+
+konig:DayWeekMonthYear a owl:Class ; 
+	rdfs:subClassOf time:TemporalUnit , schema:Enumeration . 
+
+konig:TimeInterval a owl:Class ; 
+	rdfs:label "TimeInterval" . 
+
+konig:averageScore a owl:DatatypeProperty ; 
+	schema:domainIncludes fact:ScoreAssessmentAverageScore , fact:ScoreAssessmentAverageScoreBySection , fact:ScoreAssessmentAverageScoreByGrade , fact:ScoreAssessmentAverageScoreBySchool , fact:ScoreAssessmentAverageScoreByCity , fact:ScoreAssessmentAverageScoreByState , fact:ScoreAssessmentAverageScoreByCountry ; 
+	schema:rangeIncludes xsd:int . 
+
+konig:durationUnit a owl:ObjectProperty ; 
+	schema:domainIncludes konig:TimeInterval ; 
+	schema:rangeIncludes konig:DayWeekMonthYear . 
+
+konig:incompleteCount a owl:ObjectProperty ; 
+	schema:domainIncludes fact:AssessmentEndeavorNotComplete , fact:AssessmentEndeavorNotCompleteBySection , fact:AssessmentEndeavorNotCompleteByGrade , fact:AssessmentEndeavorNotCompleteBySchool , fact:AssessmentEndeavorNotCompleteByCity , fact:AssessmentEndeavorNotCompleteByState , fact:AssessmentEndeavorNotCompleteByCountry . 
+
+konig:intervalStart a owl:DatatypeProperty ; 
+	schema:domainIncludes konig:TimeInterval ; 
+	schema:rangeIncludes xsd:date . 
+
+konig:timeInterval a owl:ObjectProperty ; 
+	schema:domainIncludes fact:LoginUniqueCountByGrade , fact:StartAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCount , fact:CompleteAssessmentUniqueCountBySection , fact:CompleteAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySchool , fact:CompleteAssessmentUniqueCountByCity , fact:CompleteAssessmentUniqueCountByState , fact:CompleteAssessmentUniqueCountByCountry , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountByGrade , fact:ScoreAssessmentUniqueCountBySchool , fact:ScoreAssessmentUniqueCountByCity , fact:ScoreAssessmentUniqueCountByState , fact:ScoreAssessmentUniqueCountByCountry , fact:ScoreAssessmentAverageScore , fact:ScoreAssessmentAverageScoreBySection , fact:ScoreAssessmentAverageScoreByGrade , fact:ScoreAssessmentAverageScoreBySchool , fact:ScoreAssessmentAverageScoreByCity , fact:ScoreAssessmentAverageScoreByState , fact:ScoreAssessmentAverageScoreByCountry , fact:AssessmentEndeavorNotComplete , fact:AssessmentEndeavorNotCompleteBySection , fact:AssessmentEndeavorNotCompleteByGrade , fact:AssessmentEndeavorNotCompleteBySchool , fact:AssessmentEndeavorNotCompleteByCity , fact:AssessmentEndeavorNotCompleteByState , fact:AssessmentEndeavorNotCompleteByCountry ; 
+	schema:rangeIncludes konig:TimeInterval . 
+
+konig:uniqueCount a owl:DatatypeProperty ; 
+	schema:domainIncludes fact:LoginUniqueCountByGrade , fact:StartAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCount , fact:CompleteAssessmentUniqueCountBySection , fact:CompleteAssessmentUniqueCountByGrade , fact:CompleteAssessmentUniqueCountBySchool , fact:CompleteAssessmentUniqueCountByCity , fact:CompleteAssessmentUniqueCountByState , fact:CompleteAssessmentUniqueCountByCountry , fact:ScoreAssessmentUniqueCountBySection , fact:ScoreAssessmentUniqueCountByGrade , fact:ScoreAssessmentUniqueCountBySchool , fact:ScoreAssessmentUniqueCountByCity , fact:ScoreAssessmentUniqueCountByState , fact:ScoreAssessmentUniqueCountByCountry ; 
+	schema:rangeIncludes xsd:int . 

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/prov.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/prov.ttl
@@ -1,0 +1,17 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xas: <http://schema.pearson.com/ns/activity/> .
+
+prov: a owl:Ontology ; 
+	vann:preferredNamespacePrefix "prov" ; 
+	rdfs:label "W3C Provenance Ontology" ; 
+	rdfs:comment "An ontology used to describe entities, activities and people involved in producing a piece of data or some thing." . 
+
+prov:Activity a owl:Class . 
+
+prov:wasGeneratedBy a owl:ObjectProperty ; 
+	schema:domainIncludes xas:Activate , xas:CompleteAssessment , xas:CreateLicenseKey , xas:CreateProfile , xas:StartReviewAssessment , xas:StartAssessment , xas:StartAssessmentItem , xas:ChangePassword , xas:ForgotPassword , xas:UpdateProfile ; 
+	schema:rangeIncludes prov:Activity . 

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/reg.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/reg.ttl
@@ -1,0 +1,64 @@
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix reg: <https://schema.pearson.com/ns/registrar/> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+reg: a owl:Ontology ; 
+	vann:preferredNamespacePrefix "reg" ; 
+	rdfs:label "Pearson Registrar Ontology" ; 
+	rdfs:comment "An ontology used to describe entities managed by a registrar" . 
+
+reg:GradeLevel a owl:Class ; 
+	rdfs:label "Grade Level" ; 
+	rdfs:subClassOf skos:Concept . 
+
+reg:GradeSection a owl:Class ; 
+	rdfs:label "Grade Section" . 
+
+reg:Party a owl:Class ; 
+	rdfs:label "Party" ; 
+	rdfs:comment "The class of all individuals that can have a role in an organization or enter into a contractual agreement.  This class includes people and organizations." . 
+
+reg:SchoolGrade a owl:Class ; 
+	rdfs:label "School Grade" ; 
+	rdfs:comment "A particular Grade Level at a particular school" . 
+
+reg:anonymousId a rdf:Property , owl:DatatypeProperty ; 
+	rdfs:label "Anonymous Id" ; 
+	rdfs:comment "An anonymous identifier for a Person." ; 
+	rdfs:domain schema:Person ; 
+	rdfs:range xsd:string ; 
+	schema:rangeIncludes xsd:string . 
+
+reg:grade a rdf:Property , owl:ObjectProperty ; 
+	rdfs:label "grade" ; 
+	rdfs:domain reg:GradeSection ; 
+	rdfs:range reg:SchoolGrade . 
+
+reg:gradeLevel a rdf:Property , owl:ObjectProperty ; 
+	rdfs:label "gradeLevel" ; 
+	rdfs:comment "The grade level associated with this school grade (e.g. \"K\", \"1\", \"2\", etc.)" ; 
+	rdfs:domain reg:SchoolGrade ; 
+	rdfs:range reg:GradeLevel . 
+
+reg:school a rdf:Property , owl:ObjectProperty ; 
+	rdfs:label "school" ; 
+	rdfs:domain reg:SchoolGrade ; 
+	rdfs:range schema:School . 
+
+reg:Administrator a org:Role ; 
+	schema:name "Administrator" ; 
+	rdfs:comment "The role which signifies that the individual is an administrator within some organizational unit." . 
+
+reg:Instructor a org:Role ; 
+	schema:name "Instructor" ; 
+	rdfs:comment "The role which signifies that the individual is an instructor within some organization unit, typically a course section." . 
+
+reg:Learner a org:Role ; 
+	schema:name "Learner" ; 
+	rdfs:comment "The role which signifies that the individual is a learner within some organizational unit, typically a course section." . 

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/schema.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/schema.ttl
@@ -1,0 +1,84 @@
+@prefix asmt: <https://schema.pearson.com/ns/assessment/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix reg: <https://schema.pearson.com/ns/registrar/> .
+@prefix schema: <http://schema.org/> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+schema: a owl:Ontology ; 
+	vann:preferredNamespacePrefix "schema" ; 
+	rdfs:label "Schema.org" ; 
+	rdfs:comment "An ontology developed by Google, Yahoo!, Microsoft and others to describe people, places, and things commonly found on the web." . 
+
+schema:City a owl:Class ; 
+	rdfs:label "City" ; 
+	rdfs:subClassOf schema:Place . 
+
+schema:Place a owl:Class . 
+
+schema:Country a owl:Class ; 
+	rdfs:label "Country" ; 
+	rdfs:subClassOf schema:Place . 
+
+schema:CreativeWork a owl:Class . 
+
+schema:EducationalOrganization a owl:Class ; 
+	rdfs:label "Educational Organization" ; 
+	rdfs:comment "An educational institution such as a school, college, or university." ; 
+	rdfs:subClassOf schema:Organization . 
+
+schema:Organization a owl:Class ; 
+	rdfs:label "Organization" ; 
+	rdfs:comment "The class of all organizational units.  Includes large administrative areas like a country, and small groups of people like a course section or study group." ; 
+	rdfs:subClassOf reg:Party . 
+
+schema:MobileApplication a owl:Class . 
+
+schema:Person a owl:Class ; 
+	rdfs:label "Person" ; 
+	rdfs:comment "The class of all individual people." ; 
+	rdfs:subClassOf reg:Party . 
+
+schema:School a owl:Class ; 
+	rdfs:label "School" ; 
+	rdfs:subClassOf schema:EducationalOrganization . 
+
+schema:SoftwareApplication a owl:Class . 
+
+schema:State a owl:Class ; 
+	rdfs:label "State" ; 
+	rdfs:subClassOf schema:Place . 
+
+schema:WebPage a owl:Class . 
+
+schema:containedInPlace a rdf:Property , owl:ObjectProperty ; 
+	rdfs:label "Contained In Place" ; 
+	rdfs:comment "A broader place within which the subject Place is contained" ; 
+	rdfs:domain schema:Place ; 
+	rdfs:range schema:Place . 
+
+schema:dateCreated a rdf:Property , owl:DatatypeProperty ; 
+	rdfs:label "Date Created" ; 
+	rdfs:comment "The date/time when this resource was created." ; 
+	rdfs:range xsd:dateTime . 
+
+schema:lastModified a rdf:Property , owl:DatatypeProperty ; 
+	rdfs:label "Date Modified" ; 
+	rdfs:comment "The date/time when this resource was last modified." ; 
+	rdfs:range xsd:dateTime . 
+
+schema:location a rdf:Property ; 
+	rdfs:label "Location" ; 
+	rdfs:comment "The location of the subject entity" . 
+
+schema:name a owl:DatatypeProperty ; 
+	schema:domainIncludes asmt:AssessmentInstrument , asmt:AssessmentItem , owl:Thing ; 
+	schema:rangeIncludes xsd:string . 
+
+schema:parentOrganization a rdf:Property , owl:ObjectProperty ; 
+	rdfs:label "Parent Organization" ; 
+	rdfs:comment "A broader organizational unit within which the subject organizational unit is contained." ; 
+	rdfs:domain schema:Organization ; 
+	rdfs:range schema:Organization . 

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/xas.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/owl/xas.ttl
@@ -1,0 +1,133 @@
+@prefix as: <http://www.w3.org/ns/activitystreams#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sys: <http://schema.pearson.com/ns/system/> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xas: <http://schema.pearson.com/ns/activity/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+xas: a owl:Ontology ; 
+	vann:preferredNamespacePrefix "xas" ; 
+	rdfs:label "Pearson Activity Streams" ; 
+	rdfs:comment "Pearson's extension of the Activity Streams ontology." . 
+
+xas:Activate a owl:Class ; 
+	rdfs:label "Activate" ; 
+	rdfs:comment "The process of activating a mobile app." ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:AssessmentActivity a owl:Class ; 
+	rdfs:label "Assessment Activity" ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:AssessmentEndeavor a owl:Class ; 
+	rdfs:label "Assessment Endeavor" ; 
+	rdfs:comment "The set of all assessment sessions by a given student on a given assessment instrument" ; 
+	rdfs:subClassOf xas:AssessmentActivity . 
+
+xas:AssessmentMode a owl:Class ; 
+	rdfs:label "Assessment Mode" ; 
+	rdfs:subClassOf skos:Concept . 
+
+xas:AssessmentResult a owl:Class . 
+
+xas:AssessmentSession a owl:Class ; 
+	rdfs:label "Assessment Session" ; 
+	rdfs:comment "A period of time when a given student is working on a given assessment instrument.  Each session begins with a StartAssessment event. The student may work on the same assessment instrument across multiple sessions" ; 
+	rdfs:subClassOf xas:AssessmentActivity . 
+
+xas:CaptureScore a owl:Class ; 
+	rdfs:label "Capture Score" ; 
+	rdfs:comment "The activity of capturing a learner's score on an assessment." ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:ChangePassword a owl:Class ; 
+	rdfs:label "Change Password" ; 
+	rdfs:comment "An event published when a user changes his or her password." ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:CompleteAssessment a owl:Class ; 
+	rdfs:label "Complete Assessment" ; 
+	rdfs:comment "An event which signals that a learner as completed an assessment instrument such as a quiz, test, or homework assignment" ; 
+	rdfs:subClassOf xas:AssessmentActivity . 
+
+xas:CompleteAssessmentItem a owl:Class ; 
+	rdfs:label "Complete Assessment Item" ; 
+	rdfs:comment "An event which signals that a learner has complete work on an individual assessment item." ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:CreateLicenseKey a owl:Class ; 
+	rdfs:label "Create License Key" ; 
+	rdfs:comment "The action of creating a license key." ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:CreateProfile a owl:Class ; 
+	rdfs:label "Create Profile" ; 
+	rdfs:comment "The activity of creating a user profile." ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:ForgotPassword a owl:Class . 
+
+xas:InstrumentType a owl:Class ; 
+	rdfs:label "Instrument Type" ; 
+	rdfs:comment "A class whose members are different types of \"instruments\" that can be used to perform some activity.  Examples include types of software applications (MathXL, Revel, MyPedia, etc.) and types of devices (iPhone, Chrome Web Browswer, etc.)." ; 
+	rdfs:subClassOf schema:Enumeration . 
+
+xas:ScoreAssessment a owl:Class ; 
+	rdfs:label "Score Assessment" ; 
+	rdfs:comment "An event when the teacher scores a pen and paper assessment completed by the learner" ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:StartAssessment a owl:Class ; 
+	rdfs:label "Start Assessment" ; 
+	rdfs:comment "An event which signals that a learner has started working on an assessment." ; 
+	rdfs:subClassOf xas:AssessmentActivity . 
+
+xas:StartAssessmentItem a owl:Class ; 
+	rdfs:label "Start Assessment Item" ; 
+	rdfs:comment "An event which signals that a learner has started work on an individual assessment item." ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:StartReviewAssessment a owl:Class ; 
+	rdfs:label "Start Review Assessment" ; 
+	rdfs:comment "An event published when a user starts to review a completed assessment." ; 
+	rdfs:subClassOf as:Activity . 
+
+xas:UpdateProfile a owl:Class . 
+
+xas:WorkProduct a owl:Class ; 
+	rdfs:label "Work Product" ; 
+	rdfs:comment "A class that represents the learner's work as in assignments or homework or assessments" . 
+
+xas:assessmentMode a rdf:Property , owl:ObjectProperty , owl:Class ; 
+	rdfs:label "Assessment Mode" ; 
+	rdfs:comment "A property that describes the mode the assessment was started or completed in" ; 
+	rdfs:domain xas:AssessmentActivity ; 
+	rdfs:range xas:AssessmentMode . 
+
+xas:attributedTo a owl:ObjectProperty ; 
+	schema:domainIncludes xas:WorkProduct . 
+
+xas:candidate a owl:ObjectProperty ; 
+	schema:domainIncludes xas:AssessmentResult . 
+
+xas:eventTime a rdf:Property , owl:DatatypeProperty ; 
+	rdfs:label "Event Time" ; 
+	rdfs:comment "The time at which an event occurred.  An event is something that occurs at a particular point in time.  It does not have an extended duration." ; 
+	rdfs:domain as:Activity ; 
+	rdfs:range xsd:dateTime ; 
+	schema:rangeIncludes xsd:dateTime . 
+
+xas:generatedMediaType a owl:DatatypeProperty ; 
+	schema:domainIncludes prov:Activity ; 
+	schema:rangeIncludes xsd:string . 
+
+xas:instrumentType a owl:ObjectProperty ; 
+	schema:rangeIncludes xas:InstrumentType , sys:ApplicationType . 
+
+xas:subActivityOf a owl:ObjectProperty ; 
+	schema:rangeIncludes as:Activity . 

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/shapes/shape_DayWeekMonthYearTimeIntervalShape.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/shapes/shape_DayWeekMonthYearTimeIntervalShape.ttl
@@ -1,0 +1,26 @@
+@prefix as: <http://www.w3.org/ns/activitystreams#> .
+@prefix konig: <http://www.konig.io/ns/core/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shape: <http://schema.pearson.com/shapes/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+shape:DayWeekMonthYearTimeIntervalShape a sh:Shape ; 
+	prov:wasGeneratedBy <http://www.konig.io/activity/ZiYcTI0q5KYAAAFguQz8hA> ; 
+	sh:targetClass konig:TimeInterval ; 
+	sh:property  [ 
+		sh:path konig:intervalStart ; 
+		sh:datatype xsd:date ; 
+		sh:minCount 1 ; 
+		sh:maxCount 1 ; 
+		konig:stereotype konig:dimension
+	 ]  ,  [ 
+		sh:path konig:durationUnit ; 
+		sh:class konig:DayWeekMonthYear ; 
+		sh:nodeKind sh:IRI ; 
+		sh:minCount 1 ; 
+		sh:maxCount 1 ; 
+		konig:stereotype konig:dimension ]  . 
+
+<http://www.konig.io/activity/ZiYcTI0q5KYAAAFguQz8hA> a konig:LoadModelFromSpreadsheet ; 
+	as:endTime "2018-01-02T15:45:24.407-07:00"^^xsd:dateTime . 

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/shapes/shape_LoginUniqueCountByGradeShape.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/shapes/shape_LoginUniqueCountByGradeShape.ttl
@@ -1,0 +1,60 @@
+@prefix alias: <http://schema.pearson.com/ns/alias/> .
+@prefix as: <http://www.w3.org/ns/activitystreams#> .
+@prefix fact: <http://schema.pearson.com/ns/fact/> .
+@prefix konig: <http://www.konig.io/ns/core/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix reg: <https://schema.pearson.com/ns/registrar/> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shape: <http://schema.pearson.com/shapes/> .
+@prefix xas: <http://schema.pearson.com/ns/activity/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+shape:LoginUniqueCountByGradeShape a sh:Shape ;
+	prov:wasGeneratedBy <http://www.konig.io/activity/ZiYcTI0q5KYAAAFguQz8hA> ;
+	sh:targetClass fact:LoginUniqueCountByGrade ;
+	konig:aggregationOf xas:CreateLicenseKey ;
+	konig:mediaTypeBaseName "application/vnd.pearson.loginuniquecountbygrade" ;
+	sh:property  [
+		sh:path konig:uniqueCount ;
+		sh:datatype xsd:int ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		konig:stereotype konig:measure
+	 ]  ,  [
+		sh:path alias:grade ;
+		sh:class reg:SchoolGrade ;
+		sh:nodeKind sh:IRI ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		konig:stereotype konig:dimension
+	 ]  ,  [
+		sh:path alias:school ;
+		sh:class schema:School ;
+		sh:nodeKind sh:IRI ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		konig:stereotype konig:attribute
+	 ]  ,  [
+		sh:path alias:city ;
+		sh:class schema:City ;
+		sh:nodeKind sh:IRI ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		konig:stereotype konig:attribute
+	 ]  ,  [
+		sh:path alias:country ;
+		sh:class schema:Country ;
+		sh:nodeKind sh:IRI ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		konig:stereotype konig:attribute
+	 ]  ,  [
+		sh:path konig:timeInterval ;
+		sh:shape shape:DayWeekMonthYearTimeIntervalShape ;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+		konig:stereotype konig:dimension ]  .
+
+<http://www.konig.io/activity/ZiYcTI0q5KYAAAFguQz8hA> a konig:LoadModelFromSpreadsheet ;
+	as:endTime "2018-01-02T15:45:24.407-07:00"^^xsd:dateTime .

--- a/konig-data-catalog/src/test/resources/ShapePageTest/rdf/shapes/shape_LoginUniqueCountBySchoolShape.ttl
+++ b/konig-data-catalog/src/test/resources/ShapePageTest/rdf/shapes/shape_LoginUniqueCountBySchoolShape.ttl
@@ -1,0 +1,67 @@
+@prefix alias: <http://schema.pearson.com/ns/alias/> .
+@prefix as: <http://www.w3.org/ns/activitystreams#> .
+@prefix fact: <http://schema.pearson.com/ns/fact/> .
+@prefix konig: <http://www.konig.io/ns/core/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix reg: <https://schema.pearson.com/ns/registrar/> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shape: <http://schema.pearson.com/shapes/> .
+@prefix xas: <http://schema.pearson.com/ns/activity/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+shape:LoginUniqueCountBySchoolShape a sh:Shape ; 
+	prov:wasGeneratedBy <http://www.konig.io/activity/ZiYcTI0q5KYAAAFguQz8hA> ; 
+	sh:targetClass fact:LoginUniqueCountBySchool ; 
+	konig:aggregationOf shape:LoginUniqueCountByGradeShape ; 
+	konig:rollUpBy alias:school ; 
+	konig:mediaTypeBaseName "application/vnd.pearson.loginuniquecountbyschool" . 
+
+<http://www.konig.io/activity/ZiYcTI0q5KYAAAFguQz8hA> a konig:LoadModelFromSpreadsheet ; 
+	as:endTime "2018-01-02T15:45:24.407-07:00"^^xsd:dateTime . 
+
+shape:LoginUniqueCountByGradeShape a sh:Shape ; 
+	prov:wasGeneratedBy <http://www.konig.io/activity/ZiYcTI0q5KYAAAFguQz8hA> ; 
+	sh:targetClass fact:LoginUniqueCountByGrade ; 
+	konig:aggregationOf xas:CreateLicenseKey ; 
+	konig:mediaTypeBaseName "application/vnd.pearson.loginuniquecountbygrade" ; 
+	sh:property  [ 
+		sh:path konig:uniqueCount ; 
+		sh:datatype xsd:int ; 
+		sh:minCount 1 ; 
+		sh:maxCount 1 ; 
+		konig:stereotype konig:measure
+	 ]  ,  [ 
+		sh:path alias:grade ; 
+		sh:class reg:SchoolGrade ; 
+		sh:nodeKind sh:IRI ; 
+		sh:minCount 1 ; 
+		sh:maxCount 1 ; 
+		konig:stereotype konig:dimension
+	 ]  ,  [ 
+		sh:path alias:school ; 
+		sh:class schema:School ; 
+		sh:nodeKind sh:IRI ; 
+		sh:minCount 1 ; 
+		sh:maxCount 1 ; 
+		konig:stereotype konig:attribute
+	 ]  ,  [ 
+		sh:path alias:city ; 
+		sh:class schema:City ; 
+		sh:nodeKind sh:IRI ; 
+		sh:minCount 1 ; 
+		sh:maxCount 1 ; 
+		konig:stereotype konig:attribute
+	 ]  ,  [ 
+		sh:path alias:country ; 
+		sh:class schema:Country ; 
+		sh:nodeKind sh:IRI ; 
+		sh:minCount 1 ; 
+		sh:maxCount 1 ; 
+		konig:stereotype konig:attribute
+	 ]  ,  [ 
+		sh:path konig:timeInterval ; 
+		sh:shape shape:DayWeekMonthYearTimeIntervalShape ; 
+		sh:minCount 1 ; 
+		sh:maxCount 1 ; 
+		konig:stereotype konig:dimension ]  . 


### PR DESCRIPTION
** not ready to merge **

This pull request closes #585, which concerns duplicate properties being rendered for fact Shapes, as first discovered in the mypedia project.

I have created a new unit test in ``konig-data-catalog`` which successfully reproduces the issue.

![screen shot 2018-01-03 at 1 58 17 pm](https://user-images.githubusercontent.com/1057295/34539571-3a897d56-f08e-11e7-9da4-4a8ed8d49b0f.png)

This issue appears to be occurring because the definition for ``shape:LoginUniqueCountByGradeShape`` is included in multiple files in the generated shapes directory.  The data catalog generator needs to be able to deal with this duplication and not display the properties multiple times in cases where the shape definition is duplicated across shape files.

The data-catalog generator may be able to handle this by assuming all sh:PropertyNodes for a given shape with the same sh:path value are equivalent and generating documentation for only one of them if more than 1 are found.