### PR TITLE
closes #670

### DIFF
--- a/konig-dao-sql-runtime/src/main/java/io/konig/sql/runtime/SqlShapeReadService.java
+++ b/konig-dao-sql-runtime/src/main/java/io/konig/sql/runtime/SqlShapeReadService.java
@@ -67,13 +67,12 @@ abstract public class SqlShapeReadService extends SqlGenerator implements ShapeR
 			}
 		}
 
-		String sql = toSql(struct, query);
-		executeSql(struct, sql, output, format);
+		executeSql(struct, query, output, format);
 	}
 	
 	abstract ChartSeriesFactory getChartSeriesFactory();
 
-	abstract protected void executeSql(EntityStructure struct, String sql, Writer output, Format format) throws DaoException;
+	abstract protected void executeSql(EntityStructure struct, ShapeQuery query, Writer output, Format format) throws DaoException;
 
 	
 }

--- a/konig-dao-sql-runtime/src/test/java/io/konig/sql/runtime/BigQueryShapeReadServiceTest.java
+++ b/konig-dao-sql-runtime/src/test/java/io/konig/sql/runtime/BigQueryShapeReadServiceTest.java
@@ -63,15 +63,9 @@ public class BigQueryShapeReadServiceTest  {
 					.addValue("Alice")
 				.endRow()
 			.endResponse()
+				.setNextPageToken("Zm9vPTIwMTctMTItMDU")
 		.build();
-		
-		QueryResponse response = mock(QueryResponse.class);
-		QueryResult result = mock(QueryResult.class);
-		when(response.getResult()).thenReturn(result);
-		Iterable<List<FieldValue>> sequence = null;
-		when(result.iterateAll()).thenReturn(sequence);
-		
-		
+
 		BigQueryShapeReadService service = new BigQueryShapeReadService(structService, bigQuery);
 		
 		ShapeQuery query = new ShapeQuery.Builder()
@@ -84,13 +78,16 @@ public class BigQueryShapeReadServiceTest  {
 				.build();
 			
 		StringWriter buffer = new StringWriter();
-		
 		service.execute(query, buffer, Format.JSONLD);
-		String expected = "[ {\n" + 
-				"  \"givenName\" : \"Alice\"\n" + 
-				"} ]";
+		String expected = "{\n" +
+				"  \"type\" : \"BasicContainer\",\n" +
+				"  \"nextPageToken\" : \"Zm9vPTIwMTctMTItMDU\",\n" +
+				"  \"contains\" : [ {\n" +
+				"    \"givenName\" : \"Alice\"\n" +
+				"  } ]\n" +
+				"}";
 		String actual = buffer.toString().replace("\r", "");
-		
+
 		assertEquals(expected, actual);
 	}
 

--- a/konig-dao-sql-runtime/src/test/java/io/konig/sql/runtime/MockBigQueryBuilder.java
+++ b/konig-dao-sql-runtime/src/test/java/io/konig/sql/runtime/MockBigQueryBuilder.java
@@ -49,8 +49,14 @@ public class MockBigQueryBuilder {
 		bigQuery = mock(BigQuery.class);
 		return this;
 	}
-	
-	
+
+	public MockBigQueryBuilder setNextPageToken(String nextPageToken) {
+		if(result != null) {
+			when(result.hasNextPage()).thenReturn(true);
+			when(result.getNextPageToken()).thenReturn(nextPageToken);
+		}
+		return this;
+	}
 	
 	public MockBigQueryBuilder beginResponse() {
 

--- a/konig-dao-sql-runtime/src/test/java/io/konig/sql/runtime/SqlShapeReadServiceTest.java
+++ b/konig-dao-sql-runtime/src/test/java/io/konig/sql/runtime/SqlShapeReadServiceTest.java
@@ -174,8 +174,8 @@ public class SqlShapeReadServiceTest {
 		}
 
 		@Override
-		protected void executeSql(EntityStructure struct, String sql, Writer output, Format format) throws DaoException {
-			
+		protected void executeSql(EntityStructure struct, ShapeQuery query, Writer output, Format format) throws DaoException {
+			String sql = toSql(struct, query);
 			assertEquals(expectedSQL, sql);
 			
 		}


### PR DESCRIPTION
Add pagination via BigQuery page tokens to JSONLD response. 

resolves #670

@svenk9575, @gmcfall 

I am not sure if the requirements for the updated LDP-container influenced JSONLD are set so I do not think this PR is ready to close.

For the moment, the updated JSON response looks like the following and has a nextPageToken field if and only if pagination is set and there is a next page.

```json
{
  "type" : "BasicContainer",
  "nextPageToken" : "Zm9vPTIwMTctMTItMDU",
  "contains" : [ {
    "givenName" : "Alice"
  } ]
}
```